### PR TITLE
fix dead link in code of conduct docs

### DIFF
--- a/docs/way_of_working/code-of-conduct.md
+++ b/docs/way_of_working/code-of-conduct.md
@@ -3,7 +3,7 @@ layout: page
 ---
 # Code of Conduct
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](../../CODE_OF_CONDUCT.md)
 
 We have adopted the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) Code of Conduct v2.1
 

--- a/lib/way_of_working/code_of_conduct/contributor_covenant/templates/docs/way_of_working/code-of-conduct.md
+++ b/lib/way_of_working/code_of_conduct/contributor_covenant/templates/docs/way_of_working/code-of-conduct.md
@@ -3,7 +3,7 @@ layout: page
 ---
 # Code of Conduct
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](../../CODE_OF_CONDUCT.md)
 
 We have adopted the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) Code of Conduct v2.1
 


### PR DESCRIPTION
# Pull Request Details

## What?

Fixes a dead link in the contributor badge in the code of conduct documentation

## Why?

The code of conduct documentation wasn't linking properly to the code of conduct, this raises megalinter flags (and is confusing)

## How?

We've updated the link in the documentation and in the template used to generate the documentation.

## Testing

Link works locally and on GitHub.  the megalinter errors (lychee and markdown-link-check) are resolved.
